### PR TITLE
Fix UserException constructor

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/exceptions/UserException.java
+++ b/src/main/java/com/second/festivalmanagementsystem/exceptions/UserException.java
@@ -1,6 +1,8 @@
 package com.second.festivalmanagementsystem.exceptions;
 
 public class UserException extends Exception {
-    public UserException(String message) {}//super(message);
+    public UserException(String message) {
+        super(message);
+    }
 }
 


### PR DESCRIPTION
## Summary
- correct `UserException` constructor implementation

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca1b7f08833386c81340526ee56d