### PR TITLE
Fix performance creation and submission logic

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -45,7 +45,6 @@ public class PerformanceService {
         performance.setMain_artist(loggedUser);
 
         festivalRepository.save(festival);
-        festivalRepository.save(festival);
         userRepository.save(loggedUser);
         return performanceRepository.save(performance);
     }
@@ -83,7 +82,7 @@ public class PerformanceService {
             throw new FestivalException("Performance is not created.");
         }
 
-        if (!performance.getMain_artist().equals(loggedUser) || !performance.getArtists().contains(loggedUser)) {
+        if (!performance.getMain_artist().equals(loggedUser) && !performance.getArtists().contains(loggedUser)) {
             throw new FestivalException("User is not artist in this performance");
         }
 


### PR DESCRIPTION
## Summary
- avoid duplicate festival saves when creating a performance
- correct authorization check in performance submission

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844caccf4148333bdaa50fc2d4bca10