### PR TITLE
Remove unused festival_id field

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/model/Performance.java
+++ b/src/main/java/com/second/festivalmanagementsystem/model/Performance.java
@@ -28,7 +28,6 @@ public class Performance {
     private User main_artist;
     private HashSet<User> artists;
     private User stage_manager;
-    private String festival_id;
     // Constructors, Getters, Setters, etc.
 
     public Performance() {}


### PR DESCRIPTION
## Summary
- delete the obsolete `festival_id` member from `Performance`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc2fab388333beefc74a734f92ff