### PR TITLE
Map relations between festivals, performances and users

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/model/Festival.java
+++ b/src/main/java/com/second/festivalmanagementsystem/model/Festival.java
@@ -9,6 +9,7 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 @Setter
 @Getter
@@ -39,9 +40,20 @@ public class Festival {
     private String vendorManagement;
     private FestivalState state = FestivalState.CREATED; // Possible values: CREATED, SUBMISSION, ASSIGNMENT, etc.
 
-    private HashSet<User> organizers = new HashSet<>();
-    private HashSet<Performance> performances = new HashSet<>();
-    private HashSet<User> staff = new HashSet<>();
+    @ManyToMany
+    @JoinTable(name = "festival_organizers",
+            joinColumns = @JoinColumn(name = "festival_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> organizers = new HashSet<>();
+
+    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Performance> performances = new HashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "festival_staff",
+            joinColumns = @JoinColumn(name = "festival_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> staff = new HashSet<>();
 
 
     // Constructors, Getters, Setters, etc.

--- a/src/main/java/com/second/festivalmanagementsystem/model/Performance.java
+++ b/src/main/java/com/second/festivalmanagementsystem/model/Performance.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Setter
 @Getter
@@ -20,24 +21,36 @@ public class Performance {
     private String description;
     private String genre;
     private int duration; // Duration in minutes
-    private String festivalId; // Reference to Festival
+    @ManyToOne
+    @JoinColumn(name = "festival_id")
+    private Festival festival; // Reference to Festival
     private List<String> bandMembers; // User IDs of band members
     private String technicalRequirements; // File path or content
     private PerformanceState state; // Possible values: CREATED, SUBMITTED, REVIEWED, etc.
 
+    @ManyToOne
+    @JoinColumn(name = "main_artist_id")
     private User main_artist;
-    private HashSet<User> artists;
+
+    @ManyToMany
+    @JoinTable(name = "performance_artists",
+            joinColumns = @JoinColumn(name = "performance_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> artists = new HashSet<>();
+
+    @ManyToOne
+    @JoinColumn(name = "stage_manager_id")
     private User stage_manager;
     // Constructors, Getters, Setters, etc.
 
     public Performance() {}
 
-    public Performance(String name, String description, String genre, int duration, String festivalId, List<String> bandMembers, String technicalRequirements, PerformanceState state) {
+    public Performance(String name, String description, String genre, int duration, Festival festival, List<String> bandMembers, String technicalRequirements, PerformanceState state) {
         this.name = name;
         this.description = description;
         this.genre = genre;
         this.duration = duration;
-        this.festivalId = festivalId;
+        this.festival = festival;
         this.bandMembers = bandMembers;
         this.technicalRequirements = technicalRequirements;
         this.state = state;

--- a/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
+++ b/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface PerformanceRepository extends JpaRepository<Performance, String> {
     // Find performances by festival ID
-    List<Performance> findByFestivalId(String festivalId);
+    List<Performance> findByFestival_Id(String festivalId);
 
     // Find performances by state
     List<Performance> findByState(String state);
@@ -20,9 +20,9 @@ public interface PerformanceRepository extends JpaRepository<Performance, String
     List<Performance> findByGenre(String genre);
 
     // Find performances by festival ID and state
-    List<Performance> findByFestivalIdAndState(String festivalId, String state);
+    List<Performance> findByFestival_IdAndState(String festivalId, String state);
 
-    @Query("SELECT p FROM Performance p WHERE p.genre = ?1 AND p.festivalId = ?2")
+    @Query("SELECT p FROM Performance p WHERE p.genre = ?1 AND p.festival.id = ?2")
     List<Performance> findByCriteria(String genre, String festivalId);
 
 

--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -39,7 +39,7 @@ public class PerformanceService {
         }
 
         festival.getPerformances().add(performance);
-        performance.setFestivalId(festival.getId());
+        performance.setFestival(festival);
 
         loggedUser.getMain_artist_in().add(festivalId);
         performance.setMain_artist(loggedUser);
@@ -59,7 +59,7 @@ public class PerformanceService {
     }
 
     public List<Performance> getPerformancesByFestival(String festivalId) {
-        return performanceRepository.findByFestivalId(festivalId);
+        return performanceRepository.findByFestival_Id(festivalId);
     }
 
     public void deletePerformance(String id) {


### PR DESCRIPTION
## Summary
- add ManyToMany and OneToMany relations in `Festival`
- map artists and managers in `Performance`
- update repository queries and service logic for new mappings

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf90eabc83338309538cc1d380f0