### PR TITLE
Fix permission check for adding artists

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -104,7 +104,8 @@ public class PerformanceService {
         if (performance.getState() != PerformanceState.CREATED) {
             throw new PerformanceException("Performance is not created.");
         }
-        if (!performance.getMain_artist().equals(loggedUser) || !performance.getArtists().contains(loggedUser)) {
+        if (!performance.getMain_artist().equals(loggedUser) &&
+                !performance.getArtists().contains(loggedUser)) {
             throw new PerformanceException("User is not artist in this performance");
         }
 


### PR DESCRIPTION
## Summary
- when adding an artist to a performance, allow action if the logged user is either the main artist or an existing band member

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0545fcc8333858955ab76438819