### PR TITLE
Fix festival creation saves organizer relationship

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/FestivalService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/FestivalService.java
@@ -37,8 +37,10 @@ public class FestivalService {
         }
 
         festival.getOrganizers().add(loggeduser);
-        loggeduser.getOrganizer_in().add(festival.getId());
-        return festivalRepository.save(festival);
+        Festival saved = festivalRepository.save(festival);
+        loggeduser.getOrganizer_in().add(saved.getId());
+        userRepository.save(loggeduser);
+        return saved;
 
     }
 


### PR DESCRIPTION
## Summary
- save the festival before adding its ID to the user's organizer list
- persist user update when creating a festival

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0d8c0d88333b0df5e45b82e8094