### PR TITLE
Simplify artist lookup

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -91,9 +91,7 @@ public class PerformanceService {
     }
 
     public Performance addArtist(String id, User loggedUser, String artist) throws PerformanceException {
-        Optional<User> artistUser = Optional.empty();
-
-        artistUser = userRepository.findByUsername(artist);
+        Optional<User> artistUser = userRepository.findByUsername(artist);
         if (!artistUser.isPresent()) {
             throw new PerformanceException("Artist username does not exist");
         }


### PR DESCRIPTION
## Summary
- streamline artist lookup in PerformanceService

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844d55cb7b48333b76114dfa00bfd74