### PR TITLE
Update repository state query signatures

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/repository/FestivalRepository.java
+++ b/src/main/java/com/second/festivalmanagementsystem/repository/FestivalRepository.java
@@ -2,6 +2,7 @@ package com.second.festivalmanagementsystem.repository;
 
 
 import com.second.festivalmanagementsystem.model.Festival;
+import com.second.festivalmanagementsystem.enums.FestivalState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,7 +12,7 @@ public interface FestivalRepository extends JpaRepository<Festival, String>, Cus
     // Find festivals by name containing a keyword (case-insensitive)
     List<Festival> findByNameContainingIgnoreCase(String name);
 
-    List<Festival> findByState(String state);
+    List<Festival> findByState(FestivalState state);
     Optional<Festival> findByName(String name);
 
 

--- a/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
+++ b/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
@@ -1,6 +1,7 @@
 package com.second.festivalmanagementsystem.repository;
 
 import com.second.festivalmanagementsystem.model.Performance;
+import com.second.festivalmanagementsystem.enums.PerformanceState;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,7 +12,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, String
     List<Performance> findByFestival_Id(String festivalId);
 
     // Find performances by state
-    List<Performance> findByState(String state);
+    List<Performance> findByState(PerformanceState state);
 
     // Find performances by name containing a keyword
     List<Performance> findByNameContainingIgnoreCase(String name);
@@ -20,7 +21,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, String
     List<Performance> findByGenre(String genre);
 
     // Find performances by festival ID and state
-    List<Performance> findByFestival_IdAndState(String festivalId, String state);
+    List<Performance> findByFestival_IdAndState(String festivalId, PerformanceState state);
 
     @Query("SELECT p FROM Performance p WHERE p.genre = ?1 AND p.festival.id = ?2")
     List<Performance> findByCriteria(String genre, String festivalId);


### PR DESCRIPTION
## Summary
- use enums for festival state queries
- use enums for performance state queries

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e0aac1ac83338144ca0b1881e2b7