### PR TITLE
Fix assignFestival exception message

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/FestivalService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/FestivalService.java
@@ -99,7 +99,7 @@ public class FestivalService {
         Festival festival = festivalRepository.findById(id)
                 .orElseThrow(() -> new FestivalException("Festival not found."));
         if (festival.getState() != FestivalState.SUBMISSION) {
-            throw new FestivalException("Only festivals in SUBMITTED state can be assigned.");
+            throw new FestivalException("Only festivals in SUBMISSION state can be assigned.");
         }else{
             festival.setState(FestivalState.ASSIGNMENT);
             festivalRepository.save(festival);


### PR DESCRIPTION
## Summary
- correct exception message for assigning festivals when not in the submission state

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e0adf3dc8333a9fe70219078ad9a