### PR TITLE
Fix festival retrieval method name

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
+++ b/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
@@ -92,9 +92,9 @@ public class FestivalController {
         }
     }
 
-    // Get all festivals
+    // Get a festival by ID
     @GetMapping("/{id}")
-    public ResponseEntity<?> getAllFestivals(@RequestHeader("Authorization") String authHeader,@PathVariable String id) {
+    public ResponseEntity<?> getFestivalById(@RequestHeader("Authorization") String authHeader,@PathVariable String id) {
         return ResponseEntity.ok(festivalService.getFestivalById(id));
     }
 


### PR DESCRIPTION
## Summary
- rename controller method `getFestivalById`
- update the associated javadoc comment

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e0aed764833389f328a3cf8804f4