### PR TITLE
Implement conditional performance search

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -70,7 +70,20 @@ public class PerformanceService {
         performanceRepository.deleteById(id);
     }
     public List<Performance> searchPerformances(String genre, String festivalId) {
-        return performanceRepository.findByCriteria(genre, festivalId);
+        boolean hasGenre = genre != null && !genre.isEmpty();
+        boolean hasFestival = festivalId != null && !festivalId.isEmpty();
+
+        if (hasGenre && hasFestival) {
+            return performanceRepository.findByCriteria(genre, festivalId);
+        }
+        if (hasGenre) {
+            return performanceRepository.findByGenre(genre);
+        }
+        if (hasFestival) {
+            return performanceRepository.findByFestival_Id(festivalId);
+        }
+
+        return performanceRepository.findAll();
     }
 
     public Performance submitPerformance(String id, User loggedUser) throws FestivalException {


### PR DESCRIPTION
## Summary
- add genre/festival checks when searching performances

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e6da9bb483338e3664fa3552ae72