### PR TITLE
Fix getFestivalById not found handling

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
+++ b/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
@@ -94,8 +94,12 @@ public class FestivalController {
 
     // Get a festival by ID
     @GetMapping("/{id}")
-    public ResponseEntity<?> getFestivalById(@RequestHeader("Authorization") String authHeader,@PathVariable String id) {
-        return ResponseEntity.ok(festivalService.getFestivalById(id));
+    public ResponseEntity<?> getFestivalById(@RequestHeader("Authorization") String authHeader, @PathVariable String id) {
+        Optional<Festival> festival = festivalService.getFestivalById(id);
+        if (festival.isPresent()) {
+            return ResponseEntity.ok(festival.get());
+        }
+        return ResponseEntity.notFound().build();
     }
 
     @GetMapping("/search")


### PR DESCRIPTION
## Summary
- return `404 Not Found` when festival ID is absent

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e6dfdcc083339b0ddbb5a1bd30e2