### PR TITLE
Enforce unique performance name per festival

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/controller/PerformanceController.java
+++ b/src/main/java/com/second/festivalmanagementsystem/controller/PerformanceController.java
@@ -47,6 +47,8 @@ public class PerformanceController {
             performance.setState(PerformanceState.CREATED); // Default state
             Performance createdPerformance = performanceService.createPerformance(performance, loggedUser, id);
             return ResponseEntity.ok(createdPerformance);
+        } catch (PerformanceException e) {
+            return ResponseEntity.status(400).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error creating performance: " + e.getMessage());
         }

--- a/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
+++ b/src/main/java/com/second/festivalmanagementsystem/repository/PerformanceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceRepository extends JpaRepository<Performance, String> {
     // Find performances by festival ID
@@ -22,6 +23,8 @@ public interface PerformanceRepository extends JpaRepository<Performance, String
 
     // Find performances by festival ID and state
     List<Performance> findByFestival_IdAndState(String festivalId, PerformanceState state);
+
+    Optional<Performance> findByNameAndFestival_Id(String name, String festivalId);
 
     @Query("SELECT p FROM Performance p WHERE p.genre = ?1 AND p.festival.id = ?2")
     List<Performance> findByCriteria(String genre, String festivalId);

--- a/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/PerformanceService.java
@@ -29,12 +29,16 @@ public class PerformanceService {
     @Autowired
     private FestivalRepository festivalRepository;
 
-    public Performance createPerformance(Performance performance, User loggedUser, String festivalId) throws FestivalException {
+    public Performance createPerformance(Performance performance, User loggedUser, String festivalId) throws FestivalException, PerformanceException {
         Festival festival = festivalRepository.findById(festivalId)
                 .orElseThrow(() -> new FestivalException("Festival not found."));
 
         if (festival.getStaff().contains(loggedUser) || festival.getOrganizers().contains(loggedUser)) {
             throw new FestivalException("User cannot perform this performance as he is organizer or staff.");
+        }
+
+        if (performanceRepository.findByNameAndFestival_Id(performance.getName(), festivalId).isPresent()) {
+            throw new PerformanceException("Performance already exists for this festival.");
         }
 
         festival.getPerformances().add(performance);


### PR DESCRIPTION
## Summary
- prevent duplicate performances per festival
- handle PerformanceException in controller
- expose repository method to find performance by name and festival

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844e72161cc8333a868ba030fe382b8