### PR TITLE
Enable registration/login without auth

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/config/SecurityConfig.java
+++ b/src/main/java/com/second/festivalmanagementsystem/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.second.festivalmanagementsystem.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/users/register", "/api/users/login").permitAll()
+                .anyRequest().authenticated()
+            )
+            .httpBasic();
+        return http.build();
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Security configuration to permit unauthenticated access to `/api/users/register` and `/api/users/login`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844c7143c5883338800c0b333e6fe6d