### PR TITLE
Implement basic authentication integration

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/config/SecurityConfig.java
+++ b/src/main/java/com/second/festivalmanagementsystem/config/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.second.festivalmanagementsystem.config;
 
+import com.second.festivalmanagementsystem.security.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -19,5 +23,15 @@ public class SecurityConfig {
             )
             .httpBasic();
         return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(CustomUserDetailsService service) {
+        return service;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
     }
 }

--- a/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
+++ b/src/main/java/com/second/festivalmanagementsystem/controller/FestivalController.java
@@ -1,12 +1,12 @@
 package com.second.festivalmanagementsystem.controller;
 
 import com.second.festivalmanagementsystem.exceptions.FestivalException;
-import com.second.festivalmanagementsystem.exceptions.UserException;
 import com.second.festivalmanagementsystem.model.Festival;
 import com.second.festivalmanagementsystem.model.User;
 import com.second.festivalmanagementsystem.service.FestivalService;
 import com.second.festivalmanagementsystem.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,14 +27,8 @@ public class FestivalController {
 
     // Create a new festival
     @PostMapping
-    public ResponseEntity<?> createFestival(@RequestHeader("Authorization") String authHeader, @RequestBody Festival festival) {
-
-        User loggedUser = null;
-        try {
-            loggedUser = userService.validateUser(authHeader);
-        } catch (UserException e) {
-            return ResponseEntity.status(400).body("wrong username or password");
-        }
+    public ResponseEntity<?> createFestival(Authentication authentication, @RequestBody Festival festival) {
+        User loggedUser = userService.getUserByUsername(authentication.getName());
 
         try {
             return ResponseEntity.ok(festivalService.createFestival(festival, loggedUser));
@@ -45,13 +39,8 @@ public class FestivalController {
 
     // Update an existing festival
     @PutMapping("/{id}")
-    public ResponseEntity<?> updateFestival(@RequestHeader("Authorization") String authHeader, @PathVariable String id, @RequestBody Festival updatedFestival) {
-        User loggedUser = null;
-        try {
-            loggedUser = userService.validateUser(authHeader);
-        } catch (UserException e) {
-            return ResponseEntity.status(400).body("wrong username or password");
-        }
+    public ResponseEntity<?> updateFestival(Authentication authentication, @PathVariable String id, @RequestBody Festival updatedFestival) {
+        User loggedUser = userService.getUserByUsername(authentication.getName());
 
         try {
             return ResponseEntity.ok(festivalService.updateFestival(id, updatedFestival, loggedUser));
@@ -61,13 +50,8 @@ public class FestivalController {
     }
 
     @PostMapping("/{id}/addorganizers")
-    public ResponseEntity<?> addOrganizers(@RequestHeader("Authorization") String authHeader, @PathVariable String id, @RequestBody ArrayList<String> organizers) {
-        User loggedUser = null;
-        try {
-            loggedUser = userService.validateUser(authHeader);
-        } catch (UserException e) {
-            return ResponseEntity.status(400).body("wrong username or password");
-        }
+    public ResponseEntity<?> addOrganizers(Authentication authentication, @PathVariable String id, @RequestBody ArrayList<String> organizers) {
+        User loggedUser = userService.getUserByUsername(authentication.getName());
 
         try {
             return ResponseEntity.ok(festivalService.addOrganizers(id, loggedUser, organizers));
@@ -77,13 +61,8 @@ public class FestivalController {
     }
 
     @PostMapping("/{id}/addstaff")
-    public ResponseEntity<?> addStaff(@RequestHeader("Authorization") String authHeader, @PathVariable String id, @RequestBody ArrayList<String> staff) {
-        User loggedUser = null;
-        try {
-            loggedUser = userService.validateUser(authHeader);
-        } catch (UserException e) {
-            return ResponseEntity.status(400).body("wrong username or password");
-        }
+    public ResponseEntity<?> addStaff(Authentication authentication, @PathVariable String id, @RequestBody ArrayList<String> staff) {
+        User loggedUser = userService.getUserByUsername(authentication.getName());
 
         try {
             return ResponseEntity.ok(festivalService.addStaff(id, loggedUser, staff));
@@ -118,13 +97,8 @@ public class FestivalController {
 
     // Delete a festival by ID
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteFestival(@RequestHeader("Authorization") String authHeader,@PathVariable String id) {
-        User loggedUser = null;
-        try {
-            loggedUser = userService.validateUser(authHeader);
-        } catch (UserException e) {
-            return ResponseEntity.status(400).body("wrong username or password");
-        }
+    public ResponseEntity<?> deleteFestival(Authentication authentication,@PathVariable String id) {
+        User loggedUser = userService.getUserByUsername(authentication.getName());
         try {
             festivalService.deleteFestival(id, loggedUser);
             return ResponseEntity.ok("Festival Deleted successfully");

--- a/src/main/java/com/second/festivalmanagementsystem/security/CustomUserDetailsService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.second.festivalmanagementsystem.security;
+
+import com.second.festivalmanagementsystem.model.User;
+import com.second.festivalmanagementsystem.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(username));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getUsername())
+                .password("{noop}" + user.getPassword())
+                .roles("USER")
+                .build();
+    }
+}

--- a/src/main/java/com/second/festivalmanagementsystem/service/UserService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/service/UserService.java
@@ -33,6 +33,11 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("User not found with id: " + id));
     }
 
+    public User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found with username: " + username));
+    }
+
 
 
     public User authenticateUser(String username, String password) {


### PR DESCRIPTION
## Summary
- add `CustomUserDetailsService` backed by `UserRepository`
- wire custom user details and password encoder in `SecurityConfig`
- fetch logged-in user from `Authentication` in controllers
- expose helper in `UserService` to lookup by username

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845a7a801cc83339ebdf124f3b94e31