### PR TITLE
Fix festival @NotNull messages

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/model/Festival.java
+++ b/src/main/java/com/second/festivalmanagementsystem/model/Festival.java
@@ -29,17 +29,17 @@ public class Festival {
     @NotNull(message = "Festival's description must not be null")
     private String description;
 
-    @NotNull(message = "Festival's description must not be null")
+    @NotNull(message = "Festival start date must not be null")
     @Temporal(TemporalType.DATE)
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date startDate;
 
-    @NotNull(message = "Festival's description must not be null")
+    @NotNull(message = "Festival end date must not be null")
     @Temporal(TemporalType.DATE)
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date endDate;
 
-    @NotNull(message = "Festival's description must not be null")
+    @NotNull(message = "Festival venue must not be null")
     private String venue;
 
     private String budget;


### PR DESCRIPTION
## Summary
- replace duplicated `@NotNull` messages for `startDate`, `endDate` and `venue`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6858807478fc8333b55d1541c9a5245b