### PR TITLE
Fix NoOp password handling

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/security/CustomUserDetailsService.java
+++ b/src/main/java/com/second/festivalmanagementsystem/security/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         return org.springframework.security.core.userdetails.User
                 .withUsername(user.getUsername())
-                .password("{noop}" + user.getPassword())
+                .password(user.getPassword())
                 .roles("USER")
                 .build();
     }


### PR DESCRIPTION
## Summary
- remove the `{noop}` prefix when building `UserDetails`

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.0)*
- `./mvnw spring-boot:run` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68588438cbb0833385cd6f4eb62d6f6b