### PR TITLE
Hide password field in user responses

### DIFF
--- a/src/main/java/com/second/festivalmanagementsystem/controller/UserController.java
+++ b/src/main/java/com/second/festivalmanagementsystem/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.second.festivalmanagementsystem.controller;
 
 import com.second.festivalmanagementsystem.model.User;
+import com.second.festivalmanagementsystem.dto.UserResponseDto;
 import com.second.festivalmanagementsystem.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +19,8 @@ public class UserController {
     public ResponseEntity<?> registerUser(@RequestBody User user) {
         try {
             User registeredUser = userService.registerUser(user);
-            return ResponseEntity.ok(registeredUser);
+            UserResponseDto dto = UserResponseDto.fromUser(registeredUser);
+            return ResponseEntity.ok(dto);
         } catch (IllegalArgumentException ex) {
             // Handle duplicate username case
             return ResponseEntity.badRequest().body("Username already exists.");
@@ -32,7 +34,8 @@ public class UserController {
             User authenticatedUser = userService.authenticateUser(
                     loginRequest.getUsername(),
                     loginRequest.getPassword());
-            return ResponseEntity.ok(authenticatedUser);
+            UserResponseDto dto = UserResponseDto.fromUser(authenticatedUser);
+            return ResponseEntity.ok(dto);
         } catch (IllegalArgumentException ex) {
             // Handle invalid credentials case
             return ResponseEntity.badRequest().body("Invalid username or password.");

--- a/src/main/java/com/second/festivalmanagementsystem/dto/UserResponseDto.java
+++ b/src/main/java/com/second/festivalmanagementsystem/dto/UserResponseDto.java
@@ -1,0 +1,26 @@
+package com.second.festivalmanagementsystem.dto;
+
+import com.second.festivalmanagementsystem.model.User;
+import java.util.Set;
+
+public record UserResponseDto(
+        String id,
+        String username,
+        String fullName,
+        Set<String> main_artist_in,
+        Set<String> artist_in,
+        Set<String> stage_manager,
+        Set<String> organizer_in,
+        Set<String> staff_in) {
+    public static UserResponseDto fromUser(User user) {
+        return new UserResponseDto(
+                user.getId(),
+                user.getUsername(),
+                user.getFullName(),
+                user.getMain_artist_in(),
+                user.getArtist_in(),
+                user.getStage_manager(),
+                user.getOrganizer_in(),
+                user.getStaff_in());
+    }
+}

--- a/src/main/java/com/second/festivalmanagementsystem/model/User.java
+++ b/src/main/java/com/second/festivalmanagementsystem/model/User.java
@@ -1,6 +1,7 @@
 package com.second.festivalmanagementsystem.model;
 
 import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,6 +24,7 @@ public class User {
     @NotNull(message = "User's username must not be null")
     private String username;
     @NotNull(message = "User's password must not be null")
+    @JsonIgnore
     private String password;
     @NotNull(message = "User's full name must not be null")
     private String fullName;


### PR DESCRIPTION
## Summary
- avoid exposing sensitive password data by ignoring the field in `User`
- return sanitized `UserResponseDto` objects from `registerUser` and `loginUser`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685884c7f0d88333b2c79b06434aa491